### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
   - nightly
   - hhvm
 
@@ -17,3 +18,4 @@ script:
 matrix:
   allow_failures:
     - php: hhvm
+    - php: nightly

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Controlled pseudo-randomness and time for PHP",
   "type": "library",
   "require-dev": {
-    "phpunit/phpunit": "^4"
+    "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5"
   },
   "autoload": {
     "psr-4": {
@@ -23,6 +23,7 @@
     }
   ],
   "require": {
+    "php": ">=5.5",
     "ruafozy/mersenne-twister": "^1.3",
     "paragonie/random_compat": "^2.0"
   }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -36,6 +36,12 @@
         </testsuite>
     </testsuites>
 
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src/Pistis</directory>
+        </whitelist>
+    </filter>
+
     <php>
         <ini name="error_reporting" value="-1"/>
         <ini name="date.timezone" value="UTC"/>

--- a/tests/Pistis/ClockTest.php
+++ b/tests/Pistis/ClockTest.php
@@ -29,6 +29,23 @@ class ClockTest extends AbstractTestCase
         self::assertSame(1, Clock::getSeed());
     }
 
+    public function invalidTimestampProvider()
+    {
+        return [
+            [-1],
+            [2147483648],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidTimestampProvider
+     * @expectedException \InvalidArgumentException
+     */
+    public function testSeedWithInvalidTimestamp($invalidTimestamp)
+    {
+        Clock::seed($invalidTimestamp);
+    }
+
     public function testGetSeedIsImplicit()
     {
         self::assertNotNull(Clock::getSeed());


### PR DESCRIPTION
# Changed log
- Add the tests are about ```testSeedWithInvalidTimestamp```.
- Set the multiple PHPUnit versions to support the different PHP versions.
- Add the white filter list setting in ```phpunit.xml.dist```.
- Add the ```php-7.2``` test in Travis CI build.
- Let the ```php-nightly``` be failed in Travis CI build because we cannot guarantee the alpha version always is successful.